### PR TITLE
Updated licence text.

### DIFF
--- a/InteractiveTools.podspec
+++ b/InteractiveTools.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "InteractiveTools"
-  s.version      = "0.1.3"
+  s.version      = "0.1.4"
   s.summary      = "ORT Interactive iOS toolbox"
 
   s.description  = <<-DESC

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Srdan Rasic (@srdanrasic)
+Copyright (c) 2016 ORT Interactive GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -186,5 +186,5 @@ The push registration process is triggered by calling the static method `[IAPush
 The code is available as github [project][home] under [MIT licence][1].
   
    [home]: https://github.com/ORT-Interactive-GmbH/InteractiveTools
-   [1]: http://revolunet.mit-license.org
+   [1]: https://github.com/swesteme/InteractiveTools/blob/master/LICENSE.md
    [2]: http://cocoapods.org


### PR DESCRIPTION
Dear ORT Interactive!
I have updated your copy of MIT licence to take ORT copyright instead of copy/paste source.
Please merge this request and make sure to add tag version 0.1.4 if it is not merged as well. I came across this mistake while reviewing the CocoaPods generated acknowledgements in settings app.